### PR TITLE
Changed start address of the application

### DIFF
--- a/memory.x
+++ b/memory.x
@@ -1,23 +1,12 @@
 /* Linker script for the nRF52 - WITHOUT SOFT DEVICE */
 MEMORY
 {
-    /* NOTE K = KiBi = 1024 bytes */
-    FLASH : ORIGIN = 0x00026000, LENGTH = 100K
-    RAM : ORIGIN = 0x20000000, LENGTH = 256K
+  /* Bootloader is split in 2 parts: the first part lives in the range 
+     0..0x1000; the second part lives at the end of the 1 MB Flash. The range
+     selected here collides with neither */ 
+  FLASH : ORIGIN = 0x1000, LENGTH = 0x7f000
+
+  /* The bootloader uses the first 8 bytes of RAM to preserve state so don't
+     touch them */
+  RAM   : ORIGIN = 0x20000008, LENGTH = 0x3fff8
 }
-
-/* This is where the call stack will be allocated. */
-/* The stack is of the full descending type. */
-/* You may want to use this variable to locate the call stack and static
-   variables in different memory regions. Below is shown the default value */
-/* _stack_start = ORIGIN(RAM) + LENGTH(RAM); */
-
-/* You can use this symbol to customize the location of the .text section */
-/* If omitted the .text section will be placed right after the .vector_table
-   section */
-/* This is required only on microcontrollers that store some configuration right
-   after the vector table */
-/* _stext = ORIGIN(FLASH) + 0x400; */
-
-/* Size of the heap (in bytes) */
-/* _heap_size = 1024; */


### PR DESCRIPTION
Changed start address of the application to `0x0000 1000` (see https://infocenter.nordicsemi.com/topic/sdk_nrf5_v17.0.0/lib_bootloader.html?cp=7_1_3_5_0_7#lib_bootloader_memory) since no SoftDevice is used. Since the bootloader uses the first 8 bytes of RAM, also the start of RAM is changed to `0x2000 0008`
